### PR TITLE
feat(content): timelineから詳細ページに移動 #13

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -21,6 +21,11 @@ const routes: Routes = [
       import('./timeline/timeline.module').then((m) => m.TimelineModule),
   },
   {
+    path: 'content/:id',
+    loadChildren: () =>
+      import('./content/content.module').then((m) => m.ContentModule),
+  },
+  {
     path: 'serch',
     loadChildren: () =>
       import('./serch/serch.module').then((m) => m.SerchModule),

--- a/src/app/content/content-routing.module.ts
+++ b/src/app/content/content-routing.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { ContentComponent } from './content/content.component';
+
+
+const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    component: ContentComponent
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class ContentRoutingModule { }

--- a/src/app/content/content.module.ts
+++ b/src/app/content/content.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { ContentRoutingModule } from './content-routing.module';
+import { ContentComponent } from './content/content.component';
+
+
+@NgModule({
+  declarations: [ContentComponent],
+  imports: [
+    CommonModule,
+    ContentRoutingModule
+  ]
+})
+export class ContentModule { }

--- a/src/app/content/content/content.component.html
+++ b/src/app/content/content/content.component.html
@@ -1,0 +1,3 @@
+<div *ngIf="note$ | async as note">
+  <p>{{ note.log }}</p>
+</div>

--- a/src/app/content/content/content.component.spec.ts
+++ b/src/app/content/content/content.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ContentComponent } from './content.component';
+
+describe('ContentComponent', () => {
+  let component: ContentComponent;
+  let fixture: ComponentFixture<ContentComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ContentComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ContentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/content/content/content.component.ts
+++ b/src/app/content/content/content.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { NoteService } from 'src/app/services/note.service';
+import { Observable } from 'rxjs';
+import { Note } from 'src/app/interfaces/note';
+
+@Component({
+  selector: 'app-content',
+  templateUrl: './content.component.html',
+  styleUrls: ['./content.component.scss']
+})
+export class ContentComponent implements OnInit {
+
+  note$: Observable<Note>;
+
+  constructor(private route: ActivatedRoute, private noteService: NoteService) {
+    route.paramMap.subscribe(params => {
+      this.note$ = this.noteService.getNote(
+        params.get('id')
+      );
+    });
+  }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/services/note.service.ts
+++ b/src/app/services/note.service.ts
@@ -35,4 +35,8 @@ export class NoteService {
       .collection<Note>('notes', ref => ref.orderBy('createdAt', 'desc'))
       .valueChanges();
   }
+
+  getNote(id: string): Observable<Note> {
+    return this.db.doc<Note>(`notes/${id}`).valueChanges();
+  }
 }

--- a/src/app/timeline/timeline-card/timeline-card.component.html
+++ b/src/app/timeline/timeline-card/timeline-card.component.html
@@ -1,17 +1,19 @@
 <div class="container" *ngIf="user$ | async as user">
-  <mat-card class="timeline-card">
-    <mat-card-header>
-      <div mat-card-avatar class="timeline-header-image" mat-mini-fab
-        [style.background-image]="'url(' + user.avatorURL + ')'">
-      </div>
-      <mat-card-title>{{ user.name }}</mat-card-title>
-      <mat-card-subtitle>{{ note.createdAt.toDate() | date: "M/d h:mm a" }}</mat-card-subtitle>
-    </mat-card-header>
+  <a routerLink="/content/{{ note.id }}">
+    <mat-card class="timeline-card">
+      <mat-card-header>
+        <div mat-card-avatar class="timeline-header-image" mat-mini-fab
+          [style.background-image]="'url(' + user.avatorURL + ')'">
+        </div>
+        <mat-card-title>{{ user.name }}</mat-card-title>
+        <mat-card-subtitle>{{ note.createdAt.toDate() | date: "M/d h:mm a" }}</mat-card-subtitle>
+      </mat-card-header>
 
-    <mat-card-content *ngIf="note">
-      <p>
-        {{ note.todo }}
-      </p>
-    </mat-card-content>
-  </mat-card>
+      <mat-card-content *ngIf="note">
+        <p>
+          {{ note.todo }}
+        </p>
+      </mat-card-content>
+    </mat-card>
+  </a>
 </div>


### PR DESCRIPTION
fixed #13 

以下の実装をしましたので、レビューをお願いします。

### 実装内容
- タイムラインでカードをクリックすると詳細ページに移動する
- contentモジュール、コンポーネントの作成
- router設定

 ### イメージ
![ss](https://user-images.githubusercontent.com/55618591/83604564-54e04600-a5b1-11ea-8dbf-c956c6ec0314.gif)
