### PR TITLE
Feature/18 アカウント設定タブの画面実装

### DIFF
--- a/src/app/mypage/mypage-profile/mypage-profile.component.html
+++ b/src/app/mypage/mypage-profile/mypage-profile.component.html
@@ -15,7 +15,6 @@
       <mat-chip-list aria-label="Gnere selection">
         <mat-chip *ngFor="let tag of user.tags">{{ tag }}</mat-chip>
       </mat-chip-list>
-      <!-- <pre>{{ user | json }}</pre> -->
     </div>
   </mat-card>
 </div>

--- a/src/app/mypage/mypage-profile/mypage-profile.component.html
+++ b/src/app/mypage/mypage-profile/mypage-profile.component.html
@@ -13,7 +13,12 @@
         {{ user.bio }}
       </p>
       <mat-chip-list aria-label="Gnere selection">
-        <mat-chip *ngFor="let tag of user.tags">{{ tag }}</mat-chip>
+        <mat-chip class="chips" *ngFor="let tag of user.tags">
+          <span>
+            <mat-icon fontSet="material-icons-outlined">local_offer</mat-icon>
+          </span>
+          {{ tag }}
+        </mat-chip>
       </mat-chip-list>
     </div>
   </mat-card>

--- a/src/app/mypage/mypage-profile/mypage-profile.component.scss
+++ b/src/app/mypage/mypage-profile/mypage-profile.component.scss
@@ -20,3 +20,10 @@
   display: flex;
   text-align: center;
 }
+.chips {
+  mat-icon {
+    font-size: 18px;
+    margin-top: 6px;
+  }
+}
+

--- a/src/app/mypage/mypage-routing.module.ts
+++ b/src/app/mypage/mypage-routing.module.ts
@@ -1,11 +1,29 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { MypageComponent } from './mypage/mypage.component';
+import { MypageSettingsComponent } from './mypage-settings/mypage-settings.component';
+import { MypageProfileComponent } from './mypage-profile/mypage-profile.component';
+import { MypageCardComponent } from './mypage-card/mypage-card.component';
 
 const routes: Routes = [
   {
     path: '',
     component: MypageComponent,
+    children: [
+      {
+        path: 'archive',
+        component: MypageCardComponent,
+      },
+      {
+        path: 'settings',
+        component: MypageSettingsComponent,
+      },
+      {
+        path: '',
+        pathMatch: 'full',
+        component: MypageProfileComponent,
+      },
+    ]
   },
 ];
 

--- a/src/app/mypage/mypage-settings/mypage-settings.component.html
+++ b/src/app/mypage/mypage-settings/mypage-settings.component.html
@@ -1,0 +1,15 @@
+<div class="container">
+  <mat-card>
+    <section>
+      <h2>決済情報</h2>
+      <p>Lorem ipsum dolor sit amet.</p>
+    </section>
+    <mat-divider></mat-divider>
+    <section>
+      <h2>退会</h2>
+      <p>Lorem ipsum dolor sit amet.</p>
+      <button mat-stroked-button color="primary">退会</button>
+    </section>
+    <mat-divider></mat-divider>
+  </mat-card>
+</div>

--- a/src/app/mypage/mypage-settings/mypage-settings.component.scss
+++ b/src/app/mypage/mypage-settings/mypage-settings.component.scss
@@ -1,0 +1,6 @@
+.container {
+  margin: 24px 0;
+}
+section {
+  padding: 40px;
+}

--- a/src/app/mypage/mypage-settings/mypage-settings.component.spec.ts
+++ b/src/app/mypage/mypage-settings/mypage-settings.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MypageSettingsComponent } from './mypage-settings.component';
+
+describe('MypageSettingsComponent', () => {
+  let component: MypageSettingsComponent;
+  let fixture: ComponentFixture<MypageSettingsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MypageSettingsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MypageSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/mypage/mypage-settings/mypage-settings.component.ts
+++ b/src/app/mypage/mypage-settings/mypage-settings.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-mypage-settings',
+  templateUrl: './mypage-settings.component.html',
+  styleUrls: ['./mypage-settings.component.scss']
+})
+export class MypageSettingsComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/mypage/mypage.module.ts
+++ b/src/app/mypage/mypage.module.ts
@@ -8,9 +8,10 @@ import { MypageCardComponent } from './mypage-card/mypage-card.component';
 import { SharedModule } from '../shared/shared.module';
 import { MypageProfileComponent } from './mypage-profile/mypage-profile.component';
 import { ProfileEditComponent } from './profile-edit/profile-edit.component';
+import { MypageSettingsComponent } from './mypage-settings/mypage-settings.component';
 
 @NgModule({
-  declarations: [MypageComponent, MypageCardComponent, MypageProfileComponent, ProfileEditComponent],
+  declarations: [MypageComponent, MypageCardComponent, MypageProfileComponent, ProfileEditComponent, MypageSettingsComponent],
   imports: [
     CommonModule,
     MypageRoutingModule,

--- a/src/app/mypage/mypage/mypage.component.html
+++ b/src/app/mypage/mypage/mypage.component.html
@@ -1,19 +1,9 @@
 <div class="mypage-container">
-  <!-- <mat-tab-group animationDuration="0ms" mat-align-tabs="center">
-    <mat-tab label="プロフィール">
-      <app-mypage-profile></app-mypage-profile>
-    </mat-tab>
-    <mat-tab label="つみあげ記録">
-      <app-mypage-card></app-mypage-card>
-    </mat-tab>
-    <mat-tab label="設定">
-      <app-mypage-settings></app-mypage-settings>
-    </mat-tab>
-  </mat-tab-group> -->
   <nav mat-tab-nav-bar mat-align-tabs="center">
     <a mat-tab-link *ngFor="let link of navLinks" [routerLinkActiveOptions]="{exact: true}" [routerLink]="link.path"
       routerLinkActive #rla="routerLinkActive" [active]="rla.isActive">
       {{link.label}}
     </a>
   </nav>
+  <router-outlet></router-outlet>
 </div>

--- a/src/app/mypage/mypage/mypage.component.html
+++ b/src/app/mypage/mypage/mypage.component.html
@@ -1,11 +1,19 @@
 <div class="mypage-container">
-  <mat-tab-group animationDuration="0ms" mat-align-tabs="center">
+  <!-- <mat-tab-group animationDuration="0ms" mat-align-tabs="center">
     <mat-tab label="プロフィール">
       <app-mypage-profile></app-mypage-profile>
     </mat-tab>
     <mat-tab label="つみあげ記録">
       <app-mypage-card></app-mypage-card>
     </mat-tab>
-    <mat-tab label="設定"></mat-tab>
-  </mat-tab-group>
+    <mat-tab label="設定">
+      <app-mypage-settings></app-mypage-settings>
+    </mat-tab>
+  </mat-tab-group> -->
+  <nav mat-tab-nav-bar mat-align-tabs="center">
+    <a mat-tab-link *ngFor="let link of navLinks" [routerLinkActiveOptions]="{exact: true}" [routerLink]="link.path"
+      routerLinkActive #rla="routerLinkActive" [active]="rla.isActive">
+      {{link.label}}
+    </a>
+  </nav>
 </div>

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -7,6 +7,20 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./mypage.component.scss']
 })
 export class MypageComponent implements OnInit {
+  navLinks = [
+    {
+      path: './',
+      label: 'プロフィール',
+    },
+    {
+      path: 'archive',
+      label: 'つみあげ記録',
+    },
+    {
+      path: 'settings',
+      label: '設定',
+    }
+  ];
 
   constructor() {
   }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -10,8 +10,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
-
-
+import { MatDividerModule } from '@angular/material/divider';
 
 @NgModule({
   declarations: [],
@@ -29,6 +28,7 @@ import { MatIconModule } from '@angular/material/icon';
     MatInputModule,
     MatChipsModule,
     MatIconModule,
+    MatDividerModule,
   ]
 })
 export class SharedModule { }

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Tsumu</title>
@@ -7,9 +8,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined" rel="stylesheet">
 </head>
+
 <body>
   <app-root></app-root>
 </body>
+
 </html>


### PR DESCRIPTION
fix #18 

以下の実装をしましたので、レビューをお願いします。

### 実装内容
- settingsComponentの作成
- 決済情報と退会のカードの見た目を実装
- プロフィール編集ダイアログで入力したデータを画面に反映
- URLに紐づくタブの実装
- chipsにMatIconを持たせる

### イメージ
![Jun-12-2020 10-09-50](https://user-images.githubusercontent.com/55618591/84454220-e7a97080-ac94-11ea-99e0-d26eb75e0e60.gif)

