### PR TITLE
Feature/47 router設定とユーザーデータの表示

### DIFF
--- a/src/app/interfaces/user-with-notes.ts
+++ b/src/app/interfaces/user-with-notes.ts
@@ -1,7 +1,0 @@
-import { User } from './user';
-import { Note } from './note';
-
-export interface UserWithNotes {
-  user: User;
-  notes: Note[];
-}

--- a/src/app/interfaces/user-with-notes.ts
+++ b/src/app/interfaces/user-with-notes.ts
@@ -1,0 +1,7 @@
+import { User } from './user';
+import { Note } from './note';
+
+export interface UserWithNotes {
+  user: User;
+  notes: Note[];
+}

--- a/src/app/interfaces/user.ts
+++ b/src/app/interfaces/user.ts
@@ -1,4 +1,5 @@
 import { firestore } from 'firebase';
+import { Note } from './note';
 
 export interface User {
   id: string;

--- a/src/app/mypage/mypage-card/mypage-card.component.ts
+++ b/src/app/mypage/mypage-card/mypage-card.component.ts
@@ -1,9 +1,14 @@
 import { Component, OnInit } from '@angular/core';
 import { NoteService } from 'src/app/services/note.service';
+import { UserService } from 'src/app/services/user.service';
 import { AuthService } from 'src/app/services/auth.service';
-import { Observable } from 'rxjs';
-import { User } from 'src/app/interfaces/user';
+
 import { Note } from 'src/app/interfaces/note';
+import { User } from 'src/app/interfaces/user';
+import { UserWithNotes } from 'src/app/interfaces/user-with-notes';
+
+import { Observable } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-mypage-card',
@@ -11,11 +16,23 @@ import { Note } from 'src/app/interfaces/note';
   styleUrls: ['./mypage-card.component.scss']
 })
 export class MypageCardComponent implements OnInit {
-  uid = this.authService.uid;
-  user$: Observable<User> = this.authService.user$;
+  uid: string;
   myNotes$: Observable<Note[]> = this.noteService.getMyNotes(this.uid);
+  user$: Observable<User>;
+  // userWithNotes$: Observable<UserWithNotes>;
 
-  constructor(private noteService: NoteService, private authService: AuthService) { }
+  constructor(
+    private authService: AuthService,
+    private noteService: NoteService,
+    private route: ActivatedRoute,
+    private userService: UserService) {
+    this.route.queryParamMap.subscribe(map => {
+      const query = map.get('id');
+      console.log(query);
+      this.uid = query;
+      this.user$ = this.userService.getUser(query);
+    });
+  }
 
   ngOnInit(): void {
   }

--- a/src/app/mypage/mypage-card/mypage-card.component.ts
+++ b/src/app/mypage/mypage-card/mypage-card.component.ts
@@ -5,7 +5,6 @@ import { AuthService } from 'src/app/services/auth.service';
 
 import { Note } from 'src/app/interfaces/note';
 import { User } from 'src/app/interfaces/user';
-import { UserWithNotes } from 'src/app/interfaces/user-with-notes';
 
 import { Observable } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
@@ -17,9 +16,8 @@ import { ActivatedRoute } from '@angular/router';
 })
 export class MypageCardComponent implements OnInit {
   uid: string;
-  myNotes$: Observable<Note[]> = this.noteService.getMyNotes(this.uid);
+  myNotes$: Observable<Note[]>;
   user$: Observable<User>;
-  // userWithNotes$: Observable<UserWithNotes>;
 
   constructor(
     private authService: AuthService,
@@ -31,6 +29,7 @@ export class MypageCardComponent implements OnInit {
       console.log(query);
       this.uid = query;
       this.user$ = this.userService.getUser(query);
+      this.myNotes$ = this.noteService.getMyNotes(this.uid);
     });
   }
 

--- a/src/app/mypage/mypage-profile/mypage-profile.component.html
+++ b/src/app/mypage/mypage-profile/mypage-profile.component.html
@@ -13,7 +13,7 @@
         {{ user.bio }}
       </p>
       <mat-chip-list aria-label="Gnere selection">
-        <mat-chip class="chips" *ngFor="let tag of user.tags">
+        <mat-chip class="chips" *ngFor="let tag of user.genres">
           <span>
             <mat-icon fontSet="material-icons-outlined">local_offer</mat-icon>
           </span>

--- a/src/app/mypage/mypage-profile/mypage-profile.component.ts
+++ b/src/app/mypage/mypage-profile/mypage-profile.component.ts
@@ -5,6 +5,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { ProfileEditComponent } from '../profile-edit/profile-edit.component';
 import { UserService } from 'src/app/services/user.service';
 import { User } from 'src/app/interfaces/user';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-mypage-profile',
@@ -13,9 +14,18 @@ import { User } from 'src/app/interfaces/user';
 })
 export class MypageProfileComponent implements OnInit {
   uid: string = this.authService.uid;
-  user$: Observable<User> = this.authService.user$;
+  user$: Observable<User>;
 
-  constructor(private authService: AuthService, private userService: UserService, private dialog: MatDialog) { }
+  constructor(
+    private authService: AuthService,
+    private userService: UserService,
+    private dialog: MatDialog,
+    private route: ActivatedRoute) {
+    this.route.queryParamMap.subscribe(map => {
+      const query = map.get('id');
+      this.user$ = this.userService.getUser(query);
+    });
+  }
 
   ngOnInit(): void {
   }

--- a/src/app/mypage/mypage/mypage.component.html
+++ b/src/app/mypage/mypage/mypage.component.html
@@ -1,9 +1,11 @@
 <div class="mypage-container">
-  <nav mat-tab-nav-bar mat-align-tabs="center">
-    <a mat-tab-link *ngFor="let link of navLinks" [routerLinkActiveOptions]="{exact: true}" [routerLink]="link.path"
-      routerLinkActive #rla="routerLinkActive" [active]="rla.isActive">
-      {{link.label}}
-    </a>
-  </nav>
-  <router-outlet></router-outlet>
+  <div *ngIf="user$ | async as user">
+    <nav mat-tab-nav-bar mat-align-tabs="center">
+      <a mat-tab-link *ngFor="let link of navLinks" [routerLinkActiveOptions]="{exact: true}" [routerLink]="link.path"
+        [queryParams]="{id: user.id}" routerLinkActive #rla="routerLinkActive" [active]="rla.isActive">
+        {{link.label}}
+      </a>
+    </nav>
+    <router-outlet></router-outlet>
+  </div>
 </div>

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -1,4 +1,8 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Observable } from 'rxjs';
+import { User } from 'src/app/interfaces/user';
+import { UserService } from 'src/app/services/user.service';
 
 
 @Component({
@@ -7,6 +11,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./mypage.component.scss']
 })
 export class MypageComponent implements OnInit {
+  user$: Observable<User>;
   navLinks = [
     {
       path: './',
@@ -22,7 +27,11 @@ export class MypageComponent implements OnInit {
     }
   ];
 
-  constructor() {
+  constructor(private route: ActivatedRoute, private userService: UserService) {
+    this.route.queryParamMap.subscribe(map => {
+      const query = map.get('id');
+      this.user$ = this.userService.getUser(query);
+    });
   }
 
   ngOnInit(): void {

--- a/src/app/search/search.module.ts
+++ b/src/app/search/search.module.ts
@@ -7,6 +7,7 @@ import { SharedModule } from '../shared/shared.module';
 import { UserCardComponent } from './user-card/user-card.component';
 
 import { MatListModule } from '@angular/material/list';
+import { RouterModule } from '@angular/router';
 
 
 @NgModule({
@@ -16,6 +17,7 @@ import { MatListModule } from '@angular/material/list';
     SearchRoutingModule,
     SharedModule,
     MatListModule,
+    RouterModule,
   ]
 })
 export class SearchModule { }

--- a/src/app/search/search/search.component.html
+++ b/src/app/search/search/search.component.html
@@ -15,9 +15,7 @@
     </mat-selection-list>
   </div>
 
-  <ul>
-    <li *ngFor="let userItem of userItems">{{ userItem.name }}</li>
-  </ul>
-
-  <app-user-card></app-user-card>
+  <div class="grid">
+    <app-user-card [user]="userItem" *ngFor="let userItem of userItems"></app-user-card>
+  </div>
 </div>

--- a/src/app/search/search/search.component.scss
+++ b/src/app/search/search/search.component.scss
@@ -30,3 +30,9 @@
   width: 400px;
   margin: 0 auto;
 }
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 24px;
+  margin-top: 24px;
+}

--- a/src/app/search/search/search.component.ts
+++ b/src/app/search/search/search.component.ts
@@ -61,7 +61,6 @@ export class SearchComponent implements OnInit {
     const facetFilters = event.source.selectedOptions.selected.map(
       item => `genres:${item.value}`
     );
-    console.log(facetFilters);
     this.search(facetFilters);
     this.updateParams({
       tags: facetFilters.length ? facetFilters.join() : null,

--- a/src/app/search/user-card/user-card.component.html
+++ b/src/app/search/user-card/user-card.component.html
@@ -2,65 +2,10 @@
   <a routerLink="">
     <mat-card>
       <div class="user">
-        <div class="user__avatar" mat-card-avatar mat-mini-fab [style.background-image]="">
+        <div class="user__avatar" mat-card-avatar mat-mini-fab [style.background-image]="'url(' + user.avatorURL + ')'">
         </div>
         <div class="user__name">
-          <p>name</p>
-        </div>
-      </div>
-    </mat-card>
-  </a>
-  <a routerLink="">
-    <mat-card>
-      <div class="user">
-        <div class="user__avatar" mat-card-avatar mat-mini-fab [style.background-image]="">
-        </div>
-        <div class="user__name">
-          <p>name</p>
-        </div>
-      </div>
-    </mat-card>
-  </a>
-  <a routerLink="">
-    <mat-card>
-      <div class="user">
-        <div class="user__avatar" mat-card-avatar mat-mini-fab [style.background-image]="">
-        </div>
-        <div class="user__name">
-          <p>name</p>
-        </div>
-      </div>
-    </mat-card>
-  </a>
-  <a routerLink="">
-    <mat-card>
-      <div class="user">
-        <div class="user__avatar" mat-card-avatar mat-mini-fab [style.background-image]="">
-        </div>
-        <div class="user__name">
-          <p>name</p>
-        </div>
-      </div>
-    </mat-card>
-  </a>
-  <a routerLink="">
-    <mat-card>
-      <div class="user">
-        <div class="user__avatar" mat-card-avatar mat-mini-fab [style.background-image]="">
-        </div>
-        <div class="user__name">
-          <p>name</p>
-        </div>
-      </div>
-    </mat-card>
-  </a>
-  <a routerLink="">
-    <mat-card>
-      <div class="user">
-        <div class="user__avatar" mat-card-avatar mat-mini-fab [style.background-image]="">
-        </div>
-        <div class="user__name">
-          <p>name</p>
+          <p>{{ user.name }}</p>
         </div>
       </div>
     </mat-card>

--- a/src/app/search/user-card/user-card.component.html
+++ b/src/app/search/user-card/user-card.component.html
@@ -1,5 +1,5 @@
 <div class="grid">
-  <a routerLink="">
+  <a [routerLink]="['/mypage']" [queryParams]="{id: user.id}">
     <mat-card>
       <div class="user">
         <div class="user__avatar" mat-card-avatar mat-mini-fab [style.background-image]="'url(' + user.avatorURL + ')'">

--- a/src/app/search/user-card/user-card.component.scss
+++ b/src/app/search/user-card/user-card.component.scss
@@ -1,6 +1,6 @@
-.grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 24px;
-  margin-top: 24px;
+
+.user__avatar {
+  background: center / cover;
+  border-radius: 50%;
+  box-shadow: none;
 }

--- a/src/app/search/user-card/user-card.component.ts
+++ b/src/app/search/user-card/user-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 
 @Component({
   selector: 'app-user-card',
@@ -6,7 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./user-card.component.scss']
 })
 export class UserCardComponent implements OnInit {
-
+  @Input() user;
 
   constructor() { }
 

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -26,8 +26,4 @@ export class UserService {
   getUser(id: string): Observable<User> {
     return this.db.doc<User>(`users/${id}`).valueChanges();
   }
-
-  // getUserWithNotes() {
-
-  // }
 }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -3,12 +3,12 @@ import { AngularFirestore } from '@angular/fire/firestore';
 import { AngularFireAuth } from '@angular/fire/auth';
 import { User } from '../interfaces/user';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class UserService {
-
 
   constructor(private db: AngularFirestore, private afAuth: AngularFireAuth, private snackBar: MatSnackBar) {
   }
@@ -22,5 +22,8 @@ export class UserService {
         duration: 2000
       });
     });
+  }
+  getUser(id: string): Observable<User> {
+    return this.db.doc<User>(`users/${id}`).valueChanges();
   }
 }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -26,4 +26,8 @@ export class UserService {
   getUser(id: string): Observable<User> {
     return this.db.doc<User>(`users/${id}`).valueChanges();
   }
+
+  // getUserWithNotes() {
+
+  // }
 }


### PR DESCRIPTION
fix #47 

以下の実装をしましたので、レビューをお願いします。

### 実装内容
- 検索でヒットしたユーザーをuser-cardで表示
- user-cardをクリックでuserIdをクエリパラメータに持つURLヘ遷移
- プロフィールと設定タブでユーザーに基づいたデータを表示

### イメージ
![Jun-23-2020 21-48-10](https://user-images.githubusercontent.com/55618591/85405523-7ffbfb00-b59b-11ea-8ad6-a06599a70ee9.gif)

![Jun-23-2020 21-48-00](https://user-images.githubusercontent.com/55618591/85405562-8e4a1700-b59b-11ea-827c-be906f899bb9.gif)
