### PR TITLE
Feature/49 タイムラインで投稿にユーザーデータを保持させる

### DIFF
--- a/src/app/interfaces/note.ts
+++ b/src/app/interfaces/note.ts
@@ -1,4 +1,5 @@
 import { firestore } from 'firebase';
+import { User } from './user';
 
 export interface Note {
   id: string;
@@ -7,4 +8,8 @@ export interface Note {
   log: string;
   authorId: string;
   createdAt: firestore.Timestamp;
+}
+
+export interface NoteWithUser extends Note {
+  author: User;
 }

--- a/src/app/services/note.service.ts
+++ b/src/app/services/note.service.ts
@@ -32,7 +32,7 @@ export class NoteService {
     });
   }
 
-  getAllNotes(): Observable<NoteWithUser[]> {
+  getNoteWithUser(): Observable<NoteWithUser[]> {
     let notes: Note[];
     return this.db.collection('notes').valueChanges().pipe(
       // noteコレクションのデータをuserデータに差し替える

--- a/src/app/services/note.service.ts
+++ b/src/app/services/note.service.ts
@@ -1,10 +1,12 @@
 import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
-import { Note } from '../interfaces/note';
-import { Observable } from 'rxjs';
 import { firestore } from 'firebase';
+import { Note, NoteWithUser } from '../interfaces/note';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
+import { Observable, of, combineLatest } from 'rxjs';
+import { switchMap, map } from 'rxjs/operators';
+import { User } from '../interfaces/user';
 
 
 @Injectable({
@@ -30,10 +32,38 @@ export class NoteService {
     });
   }
 
-  getAllNotes(): Observable<Note[]> {
-    return this.db
-      .collection<Note>('notes', ref => ref.orderBy('createdAt', 'desc'))
-      .valueChanges();
+  getAllNotes(): Observable<NoteWithUser[]> {
+    let notes: Note[];
+    return this.db.collection('notes').valueChanges().pipe(
+      // noteコレクションのデータをuserデータに差し替える
+      switchMap((posts: Note[]) => {
+        notes = posts;
+        if (notes.length) {
+          // 重複しているauthorIdをfilterで落とし、被りのないauthorIdの配列を定義
+          const uniqueAuthorIds: string[] = notes.filter((element, index, array) => {
+            // findIndexの条件に最初に合致するインデックス番号と配列のインデックス番号を比較して同じものだけ抽出する
+            return array.findIndex((value => value.authorId === element.authorId)) === index;
+            // ユニークなauthorIdを持つnoteからauthorIdを参照する
+          }).map(note => note.authorId);
+          // uniqueAuthorIdsの配列をまとめて受け取り、userのドキュメントに変換してまとめて流す
+          return combineLatest(uniqueAuthorIds.map(id => {
+            return this.db.doc(`users/${id}`).valueChanges();
+          }));
+        } else {
+          return of(null);
+        }
+      }),
+      map((users: User[]) => {
+        // notes配列の要素一つ一つに対してauthorIdと一致するuserデータを混ぜる
+        return notes.map((note: Note) => {
+          const noteWithUser: NoteWithUser = {
+            ...note,
+            author: users.find(user => user.id === note.authorId)
+          };
+          return noteWithUser;
+        });
+      })
+    );
   }
 
   getNote(id: string): Observable<Note> {

--- a/src/app/timeline/timeline-card/timeline-card.component.html
+++ b/src/app/timeline/timeline-card/timeline-card.component.html
@@ -1,17 +1,17 @@
-<div class="container" *ngIf="user$ | async as user">
-  <a routerLink="/content/{{ note.id }}">
+<div class="container">
+  <a routerLink="/content/{{ noteWithUser.id }}">
     <mat-card class="timeline-card">
       <mat-card-header>
         <div mat-card-avatar class="timeline-header-image" mat-mini-fab
-          [style.background-image]="'url(' + user.avatorURL + ')'">
+          [style.background-image]="'url(' + noteWithUser.author.avatorURL + ')'">
         </div>
-        <mat-card-title>{{ user.name }}</mat-card-title>
-        <mat-card-subtitle>{{ note.createdAt.toDate() | date: "M/d h:mm a" }}</mat-card-subtitle>
+        <mat-card-title>{{ noteWithUser.author.name }}</mat-card-title>
+        <mat-card-subtitle>{{ noteWithUser.createdAt.toDate() | date: "M/d h:mm a" }}</mat-card-subtitle>
       </mat-card-header>
 
-      <mat-card-content *ngIf="note">
+      <mat-card-content>
         <p>
-          {{ note.todo }}
+          {{ noteWithUser.todo }}
         </p>
       </mat-card-content>
     </mat-card>

--- a/src/app/timeline/timeline-card/timeline-card.component.ts
+++ b/src/app/timeline/timeline-card/timeline-card.component.ts
@@ -1,8 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { AuthService } from 'src/app/services/auth.service';
-import { Observable } from 'rxjs';
-import { User } from 'src/app/interfaces/user';
-import { Note } from 'src/app/interfaces/note';
+import { NoteWithUser } from 'src/app/interfaces/note';
 
 @Component({
   selector: 'app-timeline-card',
@@ -10,11 +7,9 @@ import { Note } from 'src/app/interfaces/note';
   styleUrls: ['./timeline-card.component.scss']
 })
 export class TimelineCardComponent implements OnInit {
-  @Input() note: Note;
+  @Input() noteWithUser: NoteWithUser;
 
-  user$: Observable<User> = this.authService.user$;
-
-  constructor(private authService: AuthService) {
+  constructor() {
   }
 
   ngOnInit(): void {

--- a/src/app/timeline/timeline/timeline.component.html
+++ b/src/app/timeline/timeline/timeline.component.html
@@ -1,3 +1,4 @@
 <div infiniteScroll (scrolled)="onScroll()">
-  <app-timeline-card [note]="note" *ngFor="let note of notes$ | async"></app-timeline-card>
+  <app-timeline-card [noteWithUser]="noteWithUser" *ngFor="let noteWithUser of notesWithUser$ | async">
+  </app-timeline-card>
 </div>

--- a/src/app/timeline/timeline/timeline.component.ts
+++ b/src/app/timeline/timeline/timeline.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { NoteService } from 'src/app/services/note.service';
 import { tap } from 'rxjs/operators';
 import { SearchService } from 'src/app/services/search.service';
+import { NoteWithUser } from 'src/app/interfaces/note';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-timeline',
@@ -9,9 +11,7 @@ import { SearchService } from 'src/app/services/search.service';
   styleUrls: ['./timeline.component.scss']
 })
 export class TimelineComponent implements OnInit {
-  notes$ = this.noteService.getAllNotes().pipe(
-    tap(data => console.log(data))
-  );
+  notesWithUser$: Observable<NoteWithUser[]> = this.noteService.getAllNotes();
 
   page = 0;
   maxPage: number;

--- a/src/app/timeline/timeline/timeline.component.ts
+++ b/src/app/timeline/timeline/timeline.component.ts
@@ -11,7 +11,7 @@ import { Observable } from 'rxjs';
   styleUrls: ['./timeline.component.scss']
 })
 export class TimelineComponent implements OnInit {
-  notesWithUser$: Observable<NoteWithUser[]> = this.noteService.getAllNotes();
+  notesWithUser$: Observable<NoteWithUser[]> = this.noteService.getNoteWithUser();
 
   page = 0;
   maxPage: number;


### PR DESCRIPTION
fix #49 

以下の実装をしましたので、レビューをお願いします。

### 実装内容
- NoteWithUserインターフェースの作成
- note.serviceのgetNoteWithUser()でnoteドキュメントにuserデータを混ぜたプロパティを取得
- タイムラインで投稿にユーザーデータを表示

### イメージ
![image](https://user-images.githubusercontent.com/55618591/85505281-ec710b80-b628-11ea-860e-3862aef82874.png)
