### PR TITLE
Feature/51 プロフィール編集ボタンを本人にのみ表示させ、編集可能にする

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,11 +3,14 @@ service cloud.firestore {
   match /databases/{database}/documents {
     match /users/{user} {
       allow read: if request.auth.uid != null;
-      allow update, delete: if request.auth.uid == resource.data.id;
+      // Authenticationのユーザーのuidとuserドキュメントのidが一致しているかつ、変更後のidが元のidと一致している
+      allow update: if request.auth.uid == resource.data.id && resource.data.id == request.resource.data.id;
+      allow delete: if request.auth.uid == resource.data.id;
     }
     match /notes/{note} {
       allow read: if request.auth.uid != null;
-      allow update, delete: if request.auth.uid == resource.data.id;
+      allow update: if request.auth.uid == resource.data.id && resource.data.id == request.resource.data.id;
+      allow delete: if request.auth.uid == resource.data.id;
     }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,13 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      allow read, write: if request.auth != null;
+    match /users/{user} {
+      allow read: if request.auth.uid != null;
+      allow update, delete: if request.auth.uid == resource.data.id;
+    }
+    match /notes/{note} {
+      allow read: if request.auth.uid != null;
+      allow update, delete: if request.auth.uid == resource.data.id;
     }
   }
 }

--- a/functions/src/utils/algolia.ts
+++ b/functions/src/utils/algolia.ts
@@ -71,7 +71,7 @@ export class Algolia {
     const idKey = param.idKey || 'id';
 
     if (param.isUpdate) {
-      await this.removeRecord(param.indexName, item.id);
+      await this.removeRecord(param.indexName, item[idKey]);
     }
 
     if (
@@ -86,7 +86,7 @@ export class Algolia {
         param.largeConcentKey
       );
     } else {
-      item.objectID = item.id;
+      item.objectID = item[idKey];
       return index.saveObject(item);
     }
   }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,7 +2,7 @@
   <app-header></app-header>
 
   <mat-sidenav-container>
-    <mat-sidenav fixedInViewport fixedTopGap="64" mode="side" [opened]="isOpened$ | async">
+    <mat-sidenav fixedInViewport fixedTopGap="64" mode="side" [opened]="isOpened">
       <app-drawer></app-drawer>
     </mat-sidenav>
     <mat-sidenav-content class="router-outlet">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,8 +8,11 @@ import { DrawerService } from './services/drawer.service';
   styleUrls: ['./app.component.scss'],
 })
 export class AppComponent {
-  isOpened$: Observable<boolean> = this.drawerService.isOpen$;
+  isOpened: boolean;
   title = 'tsumu';
 
-  constructor(private drawerService: DrawerService) {}
+  constructor(private drawerService: DrawerService) {
+    this.drawerService.toggle();
+    this.drawerService.isOpen$.subscribe(opened => this.isOpened = opened);
+  }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatDividerModule } from '@angular/material/divider';
 
 import { DrawerComponent } from './drawer/drawer.component';
+import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [
@@ -52,6 +53,7 @@ import { DrawerComponent } from './drawer/drawer.component';
     MatSnackBarModule,
     MatMenuModule,
     MatDividerModule,
+    RouterModule,
   ],
   providers: [{ provide: REGION, useValue: 'asia-northeast1' }],
   bootstrap: [AppComponent],

--- a/src/app/drawer/drawer.component.html
+++ b/src/app/drawer/drawer.component.html
@@ -1,20 +1,26 @@
-<mat-list dense>
-  <mat-nav-list>
-    <mat-list-item>
-      <mat-icon mat-list-icon>create</mat-icon>
-      <a mat-list-item routerLink="note">今日のつみあげ</a>
-    </mat-list-item>
-    <mat-list-item>
-      <mat-icon mat-list-icon>timeline</mat-icon>
-      <a mat-list-item routerLink="timeline">タイムライン</a>
-    </mat-list-item>
-    <mat-list-item>
-      <mat-icon mat-list-icon>search</mat-icon>
-      <a mat-list-item routerLink="search">ユーザー検索</a>
-    </mat-list-item>
-    <mat-list-item>
-      <mat-icon mat-list-icon>payment</mat-icon>
-      <a mat-list-item routerLink="">お支払い</a>
-    </mat-list-item>
-  </mat-nav-list>
-</mat-list>
+<div *ngIf="user$ | async as user">
+  <mat-list dense class="nav-list">
+    <mat-nav-list>
+      <a mat-list-item class="mat-list-item" routerLink="note">
+        <mat-icon mat-list-icon>create</mat-icon>
+        <p class="mat-list-item__text">今日のつみあげ</p>
+      </a>
+      <a mat-list-item routerLink="timeline">
+        <mat-icon mat-list-icon>timeline</mat-icon>
+        <p class="mat-list-item__text">タイムライン</p>
+      </a>
+      <a mat-list-item routerLink="search">
+        <mat-icon mat-list-icon>search</mat-icon>
+        <p class="mat-list-item__text">ユーザー検索</p>
+      </a>
+      <a mat-list-item [routerLink]="['/mypage']" [queryParams]="{id: user.id}">
+        <mat-icon mat-list-icon>account_circle</mat-icon>
+        <p class="mat-list-item__text">マイページ</p>
+      </a>
+      <a mat-list-item routerLink="">
+        <mat-icon mat-list-icon>payment</mat-icon>
+        <p class="mat-list-item__text">お支払い</p>
+      </a>
+    </mat-nav-list>
+  </mat-list>
+</div>

--- a/src/app/drawer/drawer.component.html
+++ b/src/app/drawer/drawer.component.html
@@ -17,6 +17,7 @@
         <mat-icon mat-list-icon>account_circle</mat-icon>
         <p class="mat-list-item__text">マイページ</p>
       </a>
+      <mat-divider></mat-divider>
       <a mat-list-item routerLink="">
         <mat-icon mat-list-icon>payment</mat-icon>
         <p class="mat-list-item__text">お支払い</p>

--- a/src/app/drawer/drawer.component.scss
+++ b/src/app/drawer/drawer.component.scss
@@ -1,0 +1,9 @@
+.nav-list {
+  width: 240px;
+}
+.mat-list-item {
+  padding: 0 16px;
+  &__text {
+    margin-left: 16px;
+  }
+}

--- a/src/app/drawer/drawer.component.ts
+++ b/src/app/drawer/drawer.component.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+import { Observable } from 'rxjs';
+import { User } from '../interfaces/user';
 
 @Component({
   selector: 'app-drawer',
@@ -6,7 +9,8 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./drawer.component.scss'],
 })
 export class DrawerComponent implements OnInit {
-  constructor() {}
+  user$: Observable<User> = this.authService.user$;
+  constructor(private authService: AuthService) { }
 
-  ngOnInit(): void {}
+  ngOnInit(): void { }
 }

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -16,15 +16,14 @@
           <span>ログアウト</span>
         </button>
         <mat-divider></mat-divider>
-        <button mat-menu-item>
+        <a mat-menu-item [routerLink]="['/mypage']" [queryParams]="{id: user.id}">
           <mat-icon>account_circle</mat-icon>
           <span>マイページ</span>
-        </button>
-        <mat-divider></mat-divider>
-        <button mat-menu-item>
+        </a>
+        <a mat-menu-item [routerLink]="['/mypage/settings']" [queryParams]="{id: user.id}">
           <mat-icon>settings</mat-icon>
           <span>設定</span>
-        </button>
+        </a>
       </mat-menu>
     </div>
     <ng-template #loginArea>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -13,9 +13,9 @@ export class HeaderComponent implements OnInit {
   constructor(
     private drawerSerivce: DrawerService,
     private authService: AuthService
-  ) {}
+  ) { }
 
-  ngOnInit(): void {}
+  ngOnInit(): void { }
 
   toggle() {
     this.drawerSerivce.toggle();

--- a/src/app/mypage/mypage-profile/mypage-profile.component.html
+++ b/src/app/mypage/mypage-profile/mypage-profile.component.html
@@ -7,7 +7,8 @@
           <p>{{ user.name }}</p>
         </div>
         <span class="spacer"></span>
-        <button class="content__button" mat-stroked-button color="primary" (click)="openDialog()">プロフィールを編集</button>
+        <button *ngIf="isEditable" class="content__button" mat-stroked-button color="primary"
+          (click)="openDialog()">プロフィールを編集</button>
       </div>
       <p class="content__bio">
         {{ user.bio }}

--- a/src/app/mypage/mypage-profile/mypage-profile.component.ts
+++ b/src/app/mypage/mypage-profile/mypage-profile.component.ts
@@ -6,6 +6,7 @@ import { ProfileEditComponent } from '../profile-edit/profile-edit.component';
 import { UserService } from 'src/app/services/user.service';
 import { User } from 'src/app/interfaces/user';
 import { ActivatedRoute } from '@angular/router';
+import { tap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-mypage-profile',
@@ -21,9 +22,13 @@ export class MypageProfileComponent implements OnInit {
     private userService: UserService,
     private dialog: MatDialog,
     private route: ActivatedRoute) {
+    this.authService.user$.pipe(
+      tap(user => console.log(user))
+    );
     this.route.queryParamMap.subscribe(map => {
       const query = map.get('id');
       this.user$ = this.userService.getUser(query);
+
     });
   }
 

--- a/src/app/mypage/mypage-profile/mypage-profile.component.ts
+++ b/src/app/mypage/mypage-profile/mypage-profile.component.ts
@@ -16,6 +16,7 @@ import { tap } from 'rxjs/operators';
 export class MypageProfileComponent implements OnInit {
   uid: string = this.authService.uid;
   user$: Observable<User>;
+  isEditable: boolean;
 
   constructor(
     private authService: AuthService,
@@ -24,11 +25,11 @@ export class MypageProfileComponent implements OnInit {
     private route: ActivatedRoute) {
     this.authService.user$.pipe(
       tap(user => console.log(user))
-    );
+    ).subscribe();
     this.route.queryParamMap.subscribe(map => {
       const query = map.get('id');
       this.user$ = this.userService.getUser(query);
-
+      this.isEditable = this.userService.getIsEditable(query, this.uid);
     });
   }
 

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -26,4 +26,12 @@ export class UserService {
   getUser(id: string): Observable<User> {
     return this.db.doc<User>(`users/${id}`).valueChanges();
   }
+
+  getIsEditable(id: string, uid: string): boolean {
+    if (id === uid) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -27,7 +27,7 @@ export class UserService {
     return this.db.doc<User>(`users/${id}`).valueChanges();
   }
 
-  getIsEditable(id: string, uid: string): boolean {
+  IsEditable(id: string, uid: string): boolean {
     if (id === uid) {
       return true;
     } else {


### PR DESCRIPTION
fix #51 

以下の実装をしましたので、レビューをお願いします。

 ### 実装内容
- プロフィール編集ボタンの表示切り替え
- firestore rules変更による編集権限の設定
- サイドナビのスタイル等調整

 ### イメージ
![Jun-27-2020 11-57-34](https://user-images.githubusercontent.com/55618591/85913183-75788480-b86d-11ea-819d-27aa417a962d.gif)
