### PR TITLE
Feature/39 firestoreルールの設定

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,6 +9,7 @@ service cloud.firestore {
     }
     match /notes/{note} {
       allow read: if request.auth.uid != null;
+      allow create: if request.auth.uid != null;
       allow update: if request.auth.uid == resource.data.id && resource.data.id == request.resource.data.id;
       allow delete: if request.auth.uid == resource.data.id;
     }

--- a/src/app/content/content/content.component.ts
+++ b/src/app/content/content/content.component.ts
@@ -33,7 +33,7 @@ export class ContentComponent implements OnInit {
             { property: 'og:title', content: 'TSUMU - つみあげの詳細' },
             { property: 'og:description', content: 'その日のつみあげを全て表示する' },
             { property: 'og:url', content: location.href },
-            { property: 'og:image', content: '/assets/Tsumu.png' },
+            { property: 'og:image', content: 'https://tsumu-3eb2a.web.app/assets/Tsumu.png' },
             { name: 'twitter:card', content: 'Summary Card' },
           ]);
         })

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -23,7 +23,7 @@ export class HomeComponent implements OnInit {
       { property: 'og:url', content: location.href },
       { property: 'og:image', content: '/assets/Tsumu.png' },
       { property: 'twitter:title', content: 'home' },
-      { property: 'twitter:image', content: '/assets/Tsumu.png' },
+      { property: 'twitter:image', content: 'https://tsumu-3eb2a.web.app/assets/Tsumu.png' },
       { name: 'twitter:card', content: 'summary_large_image' },
     ]);
   }

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -46,7 +46,7 @@ export class MypageComponent implements OnInit {
             { property: 'og:title', content: 'TSUMU - ユーザーのマイページ' },
             { property: 'og:description', content: 'ユーザーの情報を表示させるマイページ' },
             { property: 'og:url', content: location.href },
-            { property: 'og:image', content: '/assets/Tsumu.png' },
+            { property: 'og:image', content: 'https://tsumu-3eb2a.web.app/assets/Tsumu.png' },
             { name: 'twitter:card', content: 'Summary Card' },
           ]);
         })

--- a/src/app/note/note/note.component.ts
+++ b/src/app/note/note/note.component.ts
@@ -46,7 +46,7 @@ export class NoteComponent implements OnInit {
       { property: 'og:title', content: 'TSUMU - 今日のつみあげをフォームに入力' },
       { property: 'og:description', content: 'その日やったことや学んだことをフォームに入力し、保存する。' },
       { property: 'og:url', content: location.href },
-      { property: 'og:image', content: '/assets/Tsumu.png' },
+      { property: 'og:image', content: 'https://tsumu-3eb2a.web.app/assets/Tsumu.png' },
       { name: 'twitter:card', content: 'Summary Card' },
     ]);
   }

--- a/src/app/note/note/note.component.ts
+++ b/src/app/note/note/note.component.ts
@@ -61,5 +61,6 @@ export class NoteComponent implements OnInit {
       log: this.form.value.log,
       authorId: this.uid,
     });
+    this.isComplete = true;
   }
 }

--- a/src/app/search/search/search.component.ts
+++ b/src/app/search/search/search.component.ts
@@ -30,7 +30,7 @@ export class SearchComponent implements OnInit {
       { property: 'og:title', content: 'TSUMU - ジャンルごとにユーザーを検索' },
       { property: 'og:description', content: 'AngularやFirebaseなどユーザーが学習中のジャンルをタグで絞り込み、ユーザーを検索する。' },
       { property: 'og:url', content: location.href },
-      { property: 'og:image', content: '/assets/Tsumu.png' },
+      { property: 'og:image', content: 'https://tsumu-3eb2a.web.app/assets/Tsumu.png' },
       { name: 'twitter:card', content: 'Summary Card' },
     ]);
   }

--- a/src/app/timeline/timeline/timeline.component.ts
+++ b/src/app/timeline/timeline/timeline.component.ts
@@ -31,7 +31,7 @@ export class TimelineComponent implements OnInit {
       { property: 'og:title', content: 'TSUMU - 全ユーザーのタイムライン' },
       { property: 'og:description', content: '全ユーザーが投稿した記録がタイムラインとして表示される' },
       { property: 'og:url', content: location.href },
-      { property: 'og:image', content: '/assets/Tsumu.png' },
+      { property: 'og:image', content: 'https://tsumu-3eb2a.web.app/assets/Tsumu.png' },
       { name: 'twitter:card', content: 'Summary Card' },
     ]);
   }


### PR DESCRIPTION
fix #39 

以下の実装をしましたので、レビューをお願いします。

### 実装内容
- フォームが送信できない状態だったので、createのルールを追加
- フォーム送信時にisCompleteをtrueにすることで離脱ガードを正しく適用する
- メタタグの画像のURLを絶対パスに変更

### イメージ
![Jul-13-2020 10-40-46](https://user-images.githubusercontent.com/55618591/87262573-617f8480-c4f5-11ea-8b1e-b43a49f9eeb2.gif)
