### PR TITLE
Feature/94 投稿の削除機能の実装

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -11,7 +11,7 @@ service cloud.firestore {
       allow read: if request.auth.uid != null;
       allow create: if request.auth.uid != null;
       allow update: if request.auth.uid == resource.data.id && resource.data.id == request.resource.data.id;
-      allow delete: if request.auth.uid == resource.data.id;
+      allow delete: if request.auth.uid == resource.data.authorId;
     }
   }
 }

--- a/src/app/content/content.module.ts
+++ b/src/app/content/content.module.ts
@@ -4,14 +4,17 @@ import { CommonModule } from '@angular/common';
 import { ContentRoutingModule } from './content-routing.module';
 import { ContentComponent } from './content/content.component';
 import { MatCardModule } from '@angular/material/card';
+import { SharedModule } from '../shared/shared.module';
+import { DeleteNoteComfirmComponent } from './delete-note-comfirm/delete-note-comfirm.component';
 
 
 @NgModule({
-  declarations: [ContentComponent],
+  declarations: [ContentComponent, DeleteNoteComfirmComponent],
   imports: [
     CommonModule,
     ContentRoutingModule,
     MatCardModule,
+    SharedModule,
   ]
 })
 export class ContentModule { }

--- a/src/app/content/content/content.component.html
+++ b/src/app/content/content/content.component.html
@@ -1,6 +1,12 @@
-<div class="content-container">
+<div class="content-container" *ngIf="user$ | async as user">
   <div *ngIf="note$ | async as note">
-    <p class="date">{{ note.createdAt.toDate() | date: "M月d日" }}</p>
+    <div class="header">
+      <p class="header__date">{{ note.createdAt.toDate() | date: "M月d日" }}</p>
+      <span class="header__spacer"></span>
+      <button *ngIf="user.id === note.authorId" mat-icon-button (click)="openDialog()">
+        <mat-icon>delete</mat-icon>
+      </button>
+    </div>
     <mat-card class="section">
       <p class="section__title">今日やること</p>
       <p>{{ note.todo }}</p>

--- a/src/app/content/content/content.component.scss
+++ b/src/app/content/content/content.component.scss
@@ -2,8 +2,16 @@
   max-width: 1024px;
   margin: 0 auto;
 }
-.date {
-  margin-left: 16px;
+.header {
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  &__spacer {
+    flex: 1;
+  }
+  &__date {
+    margin-left: 16px;
+  }
 }
 .section {
   margin: 8px;

--- a/src/app/content/content/content.component.ts
+++ b/src/app/content/content/content.component.ts
@@ -1,10 +1,15 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-import { NoteService } from 'src/app/services/note.service';
-import { Observable } from 'rxjs';
-import { Note } from 'src/app/interfaces/note';
+import { DeleteNoteComfirmComponent } from '../delete-note-comfirm/delete-note-comfirm.component';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Title, Meta } from '@angular/platform-browser';
+import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
+import { NoteService } from 'src/app/services/note.service';
+import { AuthService } from 'src/app/services/auth.service';
+import { Note } from 'src/app/interfaces/note';
+import { User } from 'src/app/interfaces/user';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-content',
@@ -12,21 +17,28 @@ import { tap } from 'rxjs/operators';
   styleUrls: ['./content.component.scss']
 })
 export class ContentComponent implements OnInit {
+  public user$: Observable<User> = this.authService.user$;
+  public isDeletable: boolean;
+  public note$: Observable<Note>;
 
-  note$: Observable<Note>;
+  private noteId: string;
 
   constructor(
     private route: ActivatedRoute,
     private noteService: NoteService,
+    private authService: AuthService,
+    private dialog: MatDialog,
+    private router: Router,
+    private snackBar: MatSnackBar,
     private title: Title,
     private meta: Meta
   ) {
-    route.paramMap.subscribe(params => {
-      this.note$ = this.noteService.getNote(
-        params.get('id')
-      ).pipe(
+    this.route.paramMap.subscribe(params => {
+      const noteId = params.get('id');
+      this.noteId = noteId;
+      this.note$ = this.noteService.getNote(noteId).pipe(
         tap(note => {
-          this.title.setTitle(`${note.todo} | TSUMU`);
+          this.title.setTitle(`${note?.todo} | TSUMU`);
           this.meta.addTags([
             { name: 'description', content: 'その日のつみあげを全て表示する' },
             { property: 'og:type', content: 'article' },
@@ -46,6 +58,28 @@ export class ContentComponent implements OnInit {
   }
 
   ngOnInit(): void {
+  }
+
+  openDialog() {
+    this.dialog.open(DeleteNoteComfirmComponent, {
+      autoFocus: false,
+      restoreFocus: false,
+    })
+      .afterClosed().subscribe(result => {
+        if (result) {
+          this.noteService.deleteNote(this.noteId)
+            .then(() => {
+              this.router.navigate(['/mypage'], {
+                queryParams: {
+                  id: this.authService.uid
+                }
+              });
+              this.snackBar.open('投稿を削除しました。', null, {
+                duration: 2500
+              });
+            });
+        }
+      });
   }
 
 }

--- a/src/app/content/delete-note-comfirm/delete-note-comfirm.component.html
+++ b/src/app/content/delete-note-comfirm/delete-note-comfirm.component.html
@@ -1,0 +1,7 @@
+<div mat-dialog-content>
+  <p>投稿を1件削除します。よろしいですか？</p>
+</div>
+<div mat-dialog-actions>
+  <button mat-button matDialogClose>キャンセル</button>
+  <button mat-raised-button [mat-dialog-close]="true" color="primary">削除</button>
+</div>

--- a/src/app/content/delete-note-comfirm/delete-note-comfirm.component.spec.ts
+++ b/src/app/content/delete-note-comfirm/delete-note-comfirm.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeleteNoteComfirmComponent } from './delete-note-comfirm.component';
+
+describe('DeleteNoteComfirmComponent', () => {
+  let component: DeleteNoteComfirmComponent;
+  let fixture: ComponentFixture<DeleteNoteComfirmComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DeleteNoteComfirmComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DeleteNoteComfirmComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/content/delete-note-comfirm/delete-note-comfirm.component.ts
+++ b/src/app/content/delete-note-comfirm/delete-note-comfirm.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-delete-note-comfirm',
+  templateUrl: './delete-note-comfirm.component.html',
+  styleUrls: ['./delete-note-comfirm.component.scss']
+})
+export class DeleteNoteComfirmComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+}

--- a/src/app/mypage/mypage-card/mypage-card.component.scss
+++ b/src/app/mypage/mypage-card/mypage-card.component.scss
@@ -31,9 +31,8 @@
   &__body p {
     max-height: 24px;
     font-weight: 500;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 3;
+    white-space: nowrap;
+    text-overflow: ellipsis;
     overflow: hidden;
   }
 }

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -35,7 +35,7 @@ export class MypageComponent implements OnInit {
       const query = map.get('id');
       this.user$ = this.userService.getUser(query).pipe(
         tap(data => {
-          this.title.setTitle(`${data.name} | TSUMU`);
+          this.title.setTitle(`${data?.name} | TSUMU`);
           this.meta.addTags([
             { name: 'description', content: 'ユーザーの情報を表示させるマイページ' },
             { property: 'og:type', content: 'article' },

--- a/src/app/services/note.service.ts
+++ b/src/app/services/note.service.ts
@@ -84,4 +84,8 @@ export class NoteService {
       ref.where('authorId', '==', uid))
       .valueChanges();
   }
+
+  deleteNote(noteId: string): Promise<void> {
+    return this.db.doc(`notes/${noteId}`).delete();
+  }
 }


### PR DESCRIPTION
fix #94 

以下の実装をしましたので、レビューをお願いします。

### 実装内容
- 投稿を表示させるカードで文字列の省略が機能していなかった点の修正
- 投稿の詳細ページで削除機能の実装
- deleteのrules修正

(実行後にfirestoreからドキュメントが削除されていることを確認済みです。)

### イメージ
![Aug-28-2020 16-11-46](https://user-images.githubusercontent.com/55618591/91532432-481d8500-e949-11ea-9bf5-b119cd75fdd6.gif)
